### PR TITLE
Make constructor more permissive.

### DIFF
--- a/src/parser.jl
+++ b/src/parser.jl
@@ -17,7 +17,7 @@ immutable URI
     fragment::ASCIIString
     userinfo::ASCIIString
     specifies_authority::Bool
-    URI(schema::ASCIIString,host::ASCIIString,port::Integer,path,query::ASCIIString="",fragment="",userinfo="",specifies_authority=false) = 
+    URI(schema,host,port,path,query="",fragment="",userinfo="",specifies_authority=false) = 
             new(schema,host,uint16(port),path,query,fragment,userinfo,specifies_authority)
 end
 


### PR DESCRIPTION
As discussed in #9. I believe it suffices to leave the type annotations off in the constructor; conversion attempts happen automatically.
