### PR TITLE
URIParser doesn't depend on HttpCommon

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,2 @@
 julia 0.4-
 Compat 0.3.5
-HttpCommon


### PR DESCRIPTION
Fixes circular dependency