### PR TITLE
Add `(` and `)` characters to esc.jl unwise set

### DIFF
--- a/src/esc.jl
+++ b/src/esc.jl
@@ -5,7 +5,7 @@ const control_array = vcat(map(UInt8, 0:parse(Int,"1f",16)))
 const control = utf8(ascii(control_array)*"\x7f")
 const space = utf8(" ")
 const delims = utf8("%<>\"")
-const unwise   = utf8("{}|\\^`")
+const unwise   = utf8("(){}|\\^`")
 
 const reserved = utf8(",;/?:@&=+\$![]'*#")
 # Strings to be escaped

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,10 +29,10 @@ end
 g = URI("google.com","/some/path")
 @test URI(g,port=160) == URI("http://google.com:160/some/path")
 
-@test escape("abcdef αβ 1234-=~!@#\$()_+{}|[]a;") == "abcdef%20%CE%B1%CE%B2%201234-%3D~%21%40%23%24()_%2B%7B%7D%7C%5B%5Da%3B"
+@test escape("abcdef αβ 1234-=~!@#\$()_+{}|[]a;") == "abcdef%20%CE%B1%CE%B2%201234-%3D~%21%40%23%24%28%29_%2B%7B%7D%7C%5B%5Da%3B"
 @test unescape(escape("abcdef 1234-=~!@#\$()_+{}|[]a;")) == "abcdef 1234-=~!@#\$()_+{}|[]a;"
 
-@test escape_form("abcdef 1234-=~!@#\$()_+{}|[]a;") == "abcdef+1234-%3D~%21%40%23%24()_%2B%7B%7D%7C%5B%5Da%3B"
+@test escape_form("abcdef 1234-=~!@#\$()_+{}|[]a;") == "abcdef+1234-%3D~%21%40%23%24%28%29_%2B%7B%7D%7C%5B%5Da%3B"
 @test unescape_form(escape_form("abcdef 1234-=~!@#\$()_+{}|[]a;")) == "abcdef 1234-=~!@#\$()_+{}|[]a;"
 
 @test ("user", "password") == userinfo(URI("https://user:password@httphost:9000/path1/path2;paramstring?q=a&p=r#frag"))


### PR DESCRIPTION
When creating a canonical request string to sign for an [AWS2 Signaure](http://docs.aws.amazon.com/general/latest/gr/signature-version-2.html), and invalid signature is generated unless `(` and `)` are escaped.