### PR TITLE
Fixed Compat deprecation warnings.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ os:
   - linux
   - osx
 julia:
-  - 0.4
   - 0.5
+  - 0.6
   - nightly
 notifications:
   email: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.4
+julia 0.5
 Compat 0.9.5

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -9,13 +9,13 @@ is_host_char(c) = isalnum(c) || (c == '.') || (c == '-') || (c == '_') || (c == 
 
 
 immutable URI
-    scheme::Compat.ASCIIString
-    host::Compat.ASCIIString
+    scheme::String
+    host::String
     port::UInt16
-    path::Compat.ASCIIString
-    query::Compat.ASCIIString
-    fragment::Compat.ASCIIString
-    userinfo::Compat.ASCIIString
+    path::String
+    query::String
+    fragment::String
+    userinfo::String
     specifies_authority::Bool
     URI(scheme,host,port,path,query="",fragment="",userinfo="",specifies_authority=false) =
             new(scheme,host,UInt16(port),path,query,fragment,userinfo,specifies_authority)

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,13 +1,13 @@
 function _precompile_()
     ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
-    precompile(URIParser.parse_url, (Compat.ASCIIString,))
-    precompile(URIParser.parse_authority, (Compat.ASCIIString, Bool,))
-    precompile(URIParser.escape_with, (Compat.ASCIIString, Compat.String,))
+    precompile(URIParser.parse_url, (String,))
+    precompile(URIParser.parse_authority, (String, Bool,))
+    precompile(URIParser.escape_with, (String, Compat.String,))
     precompile(URIParser.is_host_char, (Char,))
     precompile(URIParser.is_url_char, (Char,))
     precompile(URIParser.isnum, (Char,))
     precompile(URIParser.is_mark, (Char,))
     precompile(URIParser.is_userinfo_char, (Char,))
-    precompile(URIParser.escape, (Compat.ASCIIString,))
+    precompile(URIParser.escape, (String,))
     precompile(URIParser.ishex, (Char,))
 end


### PR DESCRIPTION
- Converted Compat.ASCIIString to String.
- Bumped julia minimum version number as Compat has dropped support for 0.4.