### PR TITLE
Allow escape sequence in host

### DIFF
--- a/src/parser.jl
+++ b/src/parser.jl
@@ -111,6 +111,20 @@ function parse_authority(authority,seen_at)
         elseif state == :http_host
             if ch == ':'
                 state = :http_host_port_start
+            elseif ch == '%'
+                pos_escape_char2 = nextind(authority, li, 2)
+                if pos_escape_char2 > ncodeunits(authority)
+                    error("Invalid escape sequence in host")
+                end
+
+                pos_escape_char1 = nextind(authority, i)
+
+                if ishex(authority[pos_escape_char1]) && ishex(authority[pos_escape_char2])
+                    li = pos_escape_char2
+                    (ch,i) = iterate(authority,li)
+                else
+                    error("Invalid escape sequence in host")
+                end
             elseif !is_host_char(ch)
                 error("Unexpected character '$ch' in host")
             end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -67,3 +67,10 @@ g = URI("google.com","/some/path")
 # Issue #2
 @test sprint(show, MIME("text/html"), URI("http://google.com")) ==
     """<a href="http://google.com/">http://google.com/</a>"""
+
+@test URI("file://wsl%24/Ubuntu-18.04/foo/bar") == URI("file", "wsl%24", 0, "/Ubuntu-18.04/foo/bar")
+
+@test URI("file://wsl%24more/Ubuntu-18.04/foo/bar") == URI("file", "wsl%24more", 0, "/Ubuntu-18.04/foo/bar")
+
+# Test that an invalid escape sequence throws an error
+@test_throws ErrorException URI("file://wsl%2more/Ubuntu-18.04/foo/bar")


### PR DESCRIPTION
We need to support escape sequences in the host for the VS Code extension.

This is very much the minimal patch to enable the scenario that errors in the VS Code extension.

@ZacLN, could you take a look whether that makes sense to you? We are seeing crash reports for the URI of the kind that I added to the tests.